### PR TITLE
Tiny fixes to cge-2d-particle-emitter

### DIFF
--- a/demo/CastleEngineManifest.xml
+++ b/demo/CastleEngineManifest.xml
@@ -3,4 +3,9 @@
   standalone_source="test_particle_emitter.lpr"
   android_source="test_particle_emitter_android.lpr" 
   screen_orientation="landscape">
+  <compiler_options>
+    <search_paths>
+      <path value="../src/" />
+    </search_paths>
+  </compiler_options>
 </project>

--- a/src/Castle2DParticleEmitter.pas
+++ b/src/Castle2DParticleEmitter.pas
@@ -230,11 +230,10 @@ end;
 procedure TCastle2DParticleEffect.Load(const AURL: String);
 var
   Doc: TXMLDocument;       
-  XV: TXPathVariable;
 
   function XPath(const AXPath: DOMString; const ADOMNode: TDOMNode): TXPathVariable;
   begin
-    EvaluateXPathExpression(AXPath, ADOMNode);
+    Result := EvaluateXPathExpression(AXPath, ADOMNode);
   end;
 
 begin


### PR DESCRIPTION
Two small things:
1. Adding <compiler_options> to CastleEngineManifest.xml, this way one can immediately use `castle-engine compile` and it just works, it will find Castle2DParticleEmitter in ../src/ .
2. Fix two warnings/notes reported by FPC 3.1.1
