### PR TITLE
Fix compilation after CGE breaking change to TShapeNode.Material, also use Fps.ToString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+castle-engine-output
+demo/test_particle_emitter
+demo/*.exe
+demo/*.dll

--- a/demo/game.pas
+++ b/demo/game.pas
@@ -123,7 +123,7 @@ end;
 procedure WindowRender(Container: TUIContainer);
 begin
   UIFont.Print(10, 40, Yellow, Format('Particle count: %d', [Emitter.ParticleCount]));
-  UIFont.Print(10, 10, Yellow, Format('FPS: %f', [Container.Fps.RealFps]));
+  UIFont.Print(10, 10, Yellow, Format('FPS: %s', [Container.Fps.ToString]));
 end;
 
 procedure WindowUpdate(Container: TUIContainer);

--- a/src/Castle2DParticleEmitter.pas
+++ b/src/Castle2DParticleEmitter.pas
@@ -652,6 +652,7 @@ var
   ColNode: TCollisionNode;
   ShapeNode: TShapeNode;
   TriNode: TTriangleSetNode;
+  Material: TMaterialNode;
 begin
   Root := TX3DRootNode.Create;
   { We dont want the engine to perform collision detection on our particles,
@@ -664,14 +665,16 @@ begin
   ColNode.FdChildren.Add(ShapeNode);
 
   ShapeNode.Appearance := TAppearanceNode.Create;
-  ShapeNode.Material := TMaterialNode.Create;
+
+  Material := TMaterialNode.Create;
   { This is a 2d particle emitter and naturally we dont want it to be affected
     by any 3d light sources, by setting these values we tell the engine's light
     system to ignore the particles, make it very fast unlit. }
-  ShapeNode.Material.DiffuseColor := Vector3(0, 0, 0);
-  ShapeNode.Material.SpecularColor := Vector3(0, 0, 0);
-  ShapeNode.Material.AmbientIntensity := 0;
-  ShapeNode.Material.EmissiveColor := Vector3(1, 1, 1);
+  Material.DiffuseColor := Vector3(0, 0, 0);
+  Material.SpecularColor := Vector3(0, 0, 0);
+  Material.AmbientIntensity := 0;
+  Material.EmissiveColor := Vector3(1, 1, 1);
+  ShapeNode.Material := Material;
 
   FBlendModeNode := TBlendModeNode.Create;
   ShapeNode.Appearance.FdBlendMode.Value := FBlendModeNode;


### PR DESCRIPTION
1. In the last CGE commit, I broke compatibility: `TShapeNode.Material` is now `TAbstractMaterialNode` instead of `TMaterialNode`. 

    The compatibility break is unfortunately unavoidable, to have consistent API and also be able to place other nodes inside `TShapeNode.Material`, like `TTwoSidedMaterialNode` or (future, for PBR) `TPhysicalMaterial`. The `TShapeNode.Material` should always have been `TAbstractMaterialNode`, this would follow X3D specification more exactly.

    For more details, see the bottom of https://github.com/castle-engine/castle-engine/wiki/Upgrading-to-Castle-Game-Engine-6.6 .

    This PR fixes compilation of Castle2DParticleEmitter.pas with new CGE. The changed version will also work with older CGE.

2. I also sneak additional tiny modifications: 

    - use `Fps.ToString` to display full FPS information (see https://castle-engine.io/manual_optimization.php ), 

    - and `.gitignore` file to ignore `castle-engine-output` and binaries.