### PR TITLE
Various fixes - demos compilation (search paths), memory leaks, GLContextClose definition

### DIFF
--- a/demo/basic/CastleEngineManifest.xml
+++ b/demo/basic/CastleEngineManifest.xml
@@ -5,7 +5,7 @@
   screen_orientation="landscape">
   <compiler_options>
     <search_paths>
-      <path value="../src/" />
+      <path value="../../src/" />
     </search_paths>
   </compiler_options>
 </project>

--- a/demo/basic/game.pas
+++ b/demo/basic/game.pas
@@ -142,5 +142,9 @@ initialization
   Application.MainWindow := Window;
   Window.OnRender := @WindowRender;
   Window.OnUpdate := @WindowUpdate;
-
+finalization
+  FreeAndNil(EffectFire);
+  FreeAndNil(EffectTrippy);
+  FreeAndNil(EffectJellyFish);
+  FreeAndNil(EffectSpiral);
 end.

--- a/demo/basic_gpu/CastleEngineManifest.xml
+++ b/demo/basic_gpu/CastleEngineManifest.xml
@@ -5,7 +5,7 @@
   screen_orientation="landscape">
   <compiler_options>
     <search_paths>
-      <path value="../src/" />
+      <path value="../../src/" />
     </search_paths>
   </compiler_options>
 </project>

--- a/demo/basic_gpu/game.pas
+++ b/demo/basic_gpu/game.pas
@@ -142,5 +142,9 @@ initialization
   Application.MainWindow := Window;
   Window.OnRender := @WindowRender;
   Window.OnUpdate := @WindowUpdate;
-
+finalization
+  FreeAndNil(EffectFire);
+  FreeAndNil(EffectTrippy);
+  FreeAndNil(EffectJellyFish);
+  FreeAndNil(EffectSpiral);
 end.

--- a/demo/gpu/CastleEngineManifest.xml
+++ b/demo/gpu/CastleEngineManifest.xml
@@ -5,7 +5,7 @@
   screen_orientation="landscape">
   <compiler_options>
     <search_paths>
-      <path value="." />
+      <path value="../../src/" />
     </search_paths>
   </compiler_options>
 </project>

--- a/demo/gpu_instances/CastleEngineManifest.xml
+++ b/demo/gpu_instances/CastleEngineManifest.xml
@@ -5,7 +5,7 @@
   screen_orientation="landscape">
   <compiler_options>
     <search_paths>
-      <path value="." />
+      <path value="../../src/" />
     </search_paths>
   </compiler_options>
 </project>

--- a/src/Castle2DParticleEmitterGPU.pas
+++ b/src/Castle2DParticleEmitterGPU.pas
@@ -69,13 +69,13 @@ type
     FIsNeedRefresh: Boolean;
     procedure SetStartEmitting(V: Boolean);
     procedure InternalRefreshEffect;
+    procedure GLContextOpen;
   public
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
     procedure Update(const SecondsPassed: Single; var RemoveMe: TRemoveType); override;
     procedure LocalRender(const Params: TRenderParams); override;
-    procedure GLContextOpen; virtual;
-    procedure GLContextClose; virtual;
+    procedure GLContextClose; override;
 
     { This method will free the current Effect if any, init a new FEffect and
       load settings from .PEX file. }
@@ -410,14 +410,17 @@ end;
 
 procedure TCastle2DParticleEmitterGPU.GLContextClose;
 begin
-  if not Self.FIsGLContextInitialized then Exit;
-  glDeleteBuffers(1, @Self.VBOInstanced);
-  glDeleteBuffers(2, @Self.VBOs);
-  glDeleteVertexArrays(2, @Self.VAOs);
-  FreeAndNil(Self.FTransformFeedbackProgram);
-  FreeAndNil(Self.FRenderProgram);
-  glFreeTexture(Self.Texture);
-  Self.FIsGLContextInitialized := False;
+  if Self.FIsGLContextInitialized then
+  begin
+    glDeleteBuffers(1, @Self.VBOInstanced);
+    glDeleteBuffers(2, @Self.VBOs);
+    glDeleteVertexArrays(2, @Self.VAOs);
+    FreeAndNil(Self.FTransformFeedbackProgram);
+    FreeAndNil(Self.FRenderProgram);
+    glFreeTexture(Self.Texture);
+    Self.FIsGLContextInitialized := False;
+  end;
+  inherited;
 end;
 
 constructor TCastle2DParticleEmitterGPU.Create(AOwner: TComponent);
@@ -440,7 +443,6 @@ destructor TCastle2DParticleEmitterGPU.Destroy;
 begin
   if Self.FOwnEffect and Assigned(FEffect) then
     FEffect.Free;
-  Self.GLContextClose;
   inherited;
 end;
 


### PR DESCRIPTION
This PR proposes 3 fixes to the code:

( The 3 fixes are independent, sorry for pushing them together in one PR -- this seemed easier for me, and I'll make another PR soon with some upgrades to the code. Feel free to reject them selectively, of course. )

1. Fixed demos compilation (`CastleEngineManifest.xml` had `<path value="../src/" />` in most projects, instead of `<path value="../../src/" />`).

2. Compiling with memory leak detection ( https://github.com/castle-engine/castle-engine/wiki/Detecting-Memory-Leaks-Using-HeapTrc ) revealed a few memory leaks from `ApplicationInitialize`. Looks like `TCastle2DParticleEffect` were not freed.

    I solve it in this PR by freeing them in the `finalization` section. Though you can consider making `TCastle2DParticleEffect` a descendant of `TComponent`, then it could be created like `TCastle2DParticleEffect.Create(Application)` and the developer could forget (at least in simple cases) about freeing it.

3. I saw that you define virtual `TCastle2DParticleEmitterGPU.GLContextOpen` / `TCastle2DParticleEmitterGPU.GLContextClose` , thus hiding the `GLContextClose` defined at `TCastleTransform` ancestor and causing compiler warning.

    From what I understand, the reason for this is that CGE didn't give you ready `GLContextOpen`. Indeed, we do not define a `GLContextOpen` at `TCastleTransform` now, we define only `GLContextClose`. For now the descendants that actually need to initialize some OpenGL resource should do it "when needed" or "when user requests it by calling `PrepareResources`".

    So, your definition and usage of `TCastle2DParticleEmitterGPU.GLContextOpen` is 100% correct in my eyes, you solved the problem that CGE doesn't define such `GLContextOpen` for you.

    Still, you can use the CGE-provided `GLContextClose`, overriding it and calling `inherited` there. It will be automatically done when `TCastle2DParticleEmitterGPU` is destroyed. On mobile `GLContextClose` can also be called at any moment when OpenGLES context is lost -- I know that mobile OpenGLES doesn't matter now for `TCastle2DParticleEmitterGPU`, but maybe it will be in the future.

    In this PR I propose a modification that basically keeps `GLContextOpen` as it was, but changes `GLContextClose` treatment to follow CGE and override CGE method. I realize that this is somewhat ugly -- `GLContextOpen` and `GLContextClose` are not consistent, they are just not defined as a pair at CGE `TCastleTransform`. Maybe it will change one day, I do not really have a good argument for this inconsistency in CGE now, it's just an effect of various historic decisions.